### PR TITLE
fix #3

### DIFF
--- a/lib/atom-sonic.coffee
+++ b/lib/atom-sonic.coffee
@@ -19,7 +19,7 @@ module.exports = AtomSonic =
   play: (selector) ->
     editor = atom.workspace.getActiveTextEditor()
     source = editor[selector]()
-    @send '/run-code', source
+    @send '/run-code', '0', source
     atom.notifications.addSuccess "Sent source code to Sonic Pi."
 
   stop: ->


### PR DESCRIPTION
The osc API of sonic pi gets the code that needs to be played from the second argument, not the first.
